### PR TITLE
Don't modify `publicPath` for dev server

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -69,7 +69,6 @@ gulp.task("webpack-dev-server", function(callback) {
 
 	// Start a webpack-dev-server
 	new WebpackDevServer(webpack(myConfig), {
-		publicPath: "/" + myConfig.output.publicPath,
 		stats: {
 			colors: true
 		}


### PR DESCRIPTION
If, like me, one already has their `publicPath` configured with a leading slash in `webpack.config.js`, adding another slash breaks the configuration.
