### PR TITLE
Update gulpfile.js - prevent possible TypeError

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -21,7 +21,7 @@ gulp.task("build", ["webpack:build"]);
 gulp.task("webpack:build", function(callback) {
 	// modify some webpack config options
 	var myConfig = Object.create(webpackConfig);
-	myConfig.plugins = myConfig.plugins.concat(
+	myConfig.plugins = (myConfig.plugins || []).concat(
 		new webpack.DefinePlugin({
 			"process.env": {
 				// This has effect on the react lib size


### PR DESCRIPTION
Prevent `TypeError: Cannot read property 'concat' of undefined` if no plugins are specified in webpack.config.js
